### PR TITLE
Update mongodb to 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "body-parser": "1.11.x",
     "method-override": "2.3.x",
     "cookie-parser": "1.3.x",
-    "mongodb":  "1.4.x",
+    "mongodb":  "2.0.x",
     "node-uuid":"1.3.3",
     "async": "0.2.10",
     "csv": "0.2.4",


### PR DESCRIPTION
as per https://github.com/nodejs/benchmarking/issues/57 we came across an issue with mongodb following a code change in the master branch (what will be node 7).

This pull requests bumps the version of mongodb required to carry on running acmeair.

Thanks
