### PR TITLE
Remove instance of 'new require' anti-pattern

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,11 +40,11 @@ if (authServiceLocation)
 	else
 		authModule= authServiceLocation;
 	
-	authService = new require('./'+authModule+'/index.js')(settings);
+	authService = require('./'+authModule+'/index.js')(settings);
 	if (authService && "true"==process.env.enableHystrix) // wrap into command pattern
 	{
 		logger.info("Enabled Hystrix");
-		authService = new require('./acmeaircmd/index.js')(authService, settings);
+		authService = require('./acmeaircmd/index.js')(authService, settings);
 	}
 }
 
@@ -62,8 +62,8 @@ if(process.env.VCAP_SERVICES){
 }
 logger.info("db type=="+dbtype);
 
-var routes = new require('./routes/index.js')(dbtype, authService,settings);
-var loader = new require('./loader/loader.js')(routes, settings);
+var routes = require('./routes/index.js')(dbtype, authService,settings);
+var loader = require('./loader/loader.js')(routes, settings);
 
 // Setup express with 4.0.0
 

--- a/authservice/routes/index.js
+++ b/authservice/routes/index.js
@@ -24,7 +24,7 @@ module.exports = function (dbtype, settings) {
 
 	var daModuleName = "../../dataaccess/"+dbtype+"/index.js";
 	logger.info("Use dataaccess:"+daModuleName);
-	var dataaccess = new require(daModuleName)(settings);
+	var dataaccess = require(daModuleName)(settings);
 	
 	module.dbNames = dataaccess.dbNames
 	

--- a/routes/index.js
+++ b/routes/index.js
@@ -27,7 +27,7 @@ module.exports = function (dbtype, authService, settings) {
 
 	var daModuleName = "../dataaccess/"+dbtype+"/index.js";
 	logger.info("Use dataaccess:"+daModuleName);
-	var dataaccess = new require(daModuleName)(settings);
+	var dataaccess = require(daModuleName)(settings);
 	
 	module.dbNames = dataaccess.dbNames
 	


### PR DESCRIPTION
Although it works correctly in Node.js, calling 'require' as a
constructor is a discouraged and undocumented behavior, which may break
in the future. Note that removing the 'new' keyword does not change
functionality.